### PR TITLE
Add ability to provide arguments to programs

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -31,7 +31,7 @@ typedef enum {
 
 #define MAX_LEN (2048)
 
-void open_app(char *path, app_launch_mode_t mode);
+void open_app(const char *path, const char *query, app_launch_mode_t mode);
 
 /* Error code */
 int err;


### PR DESCRIPTION
Issue #65 
* If number of search results is equal to 1, you can provide arguments
  that selected application should be started with, e.g.
  surf xstarter.org
* You can select the application you want to provide arguments for by
  pressing `tab` key
* This feature works both with GUI (press Enter to start) and terminal
  applications (press C-o to start)